### PR TITLE
Update usage

### DIFF
--- a/.ci/README.md
+++ b/.ci/README.md
@@ -41,13 +41,13 @@ The following usage examples showcase the `build` command, pushing official and 
 
 ###### official image
 ```
-./.ci/build.sh --file 8/jdk/Dockerfile.openj9 --image ycsb --tag 0.17.0-8-jdk-openj9-bionic --build-args "YCSB_VERSION=${VERSION}" --push --official
+./.ci/build.sh --file 8/jdk/Dockerfile.openj9 --image ycsb:0.17.0-8-jdk-openj9-bionic --build-args "YCSB_VERSION=${VERSION}" --push --official
 ```
 This will build an image as `${DOCKER_REGISTRY}/${ARCH}/ycsb:0.17.0-8-jdk-openj9-bionic`. This image will be uploaded to the specified docker registry under the architecture namespace to mimic the official DockerHub images.
 
 ###### unofficial image/custom private registry
 ```
-./.ci/build.sh --file 8/jdk/Dockerfile.openj9 --image ycsb --tag 0.17.0-8-jdk-openj9-bionic --build-args "YCSB_VERSION=${VERSION}" --push
+./.ci/build.sh --file 8/jdk/Dockerfile.openj9 --image ycsb:0.17.0-8-jdk-openj9-bionic --build-args "YCSB_VERSION=${VERSION}" --push
 ```
 This will build an image as `${DOCKER_REGISTRY}/${DOCKER_NAMESPACE}/ycsb:${ARCH}-0.17.0-8-jdk-openj9-bionic`. This image will be uploaded to the specified docker registry and namespace with the architecture appended to the front of the build tag
 

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -31,8 +31,19 @@ IS_DRY_RUN=false        # Prints out what will happen rather than running the co
 
 usage() {
   echo -e "A docker container build script for ci pipelines \n\n"
+  echo "Options:"
+  echo "    --build-args   Set build-time variables in a space separated string (i.e. --build-args \"FOO=bar BAR=foo\")"
+  echo "    --build-opts   Set additonal build options supported by docker (i.e. --build-opts \"--pull --no-cache\")"
+  echo "-c, --context      Docker image build path to use"
+  echo "    --dry-run      Print out what will happen, do not execute"
+  echo "-f, --file         Name of the Dockerfile (Default is 'PATH/Dockerfile')"
+  echo "-i, --image        The name of the image"
+  echo "    --official     Mimic the official docker publish method for images in private registries"
+  echo "    --push         Push the image to the specified DOCKER_REGISTRY and DOCKER_NAMESPACE"
+  echo "-t, --tag          The tag name to use for the built image"
+  echo ""
   echo "Usage:"
-  echo "${0} [-f path/to/Dockerfile] --image example-docker-manifest --tag 1.0.0-8-jdk-openj9-bionic [--context build-context] [--push] [--official] [--dry-run]"
+  echo "${0} [-f|--file path/to/Dockerfile] --image example-docker-manifest --tag 1.0.0-8-jdk-openj9-bionic [-c|--context .] [--build-args \"FOO=bar\"] [--build-opts \"--pull\"] [--push] [--official] [--dry-run]"
   echo ""
 }
 
@@ -56,14 +67,14 @@ while [[ $# -gt 0 ]]; do
     DOCKER_BUILD_TAG=$2
     shift
     ;;
-    -a|--build-args)
+    --build-args)
     DOCKER_BUILD_ARGS=$2
     shift
     ;;
-    -o|--official)
+    --official)
     DOCKER_OFFICIAL=true
     ;;
-    -b|--build-opts)
+    --build-opts)
     DOCKER_BUILD_OPTS=$2
     shift
     ;;

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -37,17 +37,16 @@ usage() {
   echo "-c, --context      Docker image build path to use"
   echo "    --dry-run      Print out what will happen, do not execute"
   echo "-f, --file         Name of the Dockerfile (Default is 'PATH/Dockerfile')"
-  echo "-i, --image        The name of the image"
+  echo "-i, --image        Name of the image and optionally a tag in the 'name:tag' format"
   echo "    --official     Mimic the official docker publish method for images in private registries"
   echo "    --push         Push the image to the specified DOCKER_REGISTRY and DOCKER_NAMESPACE"
-  echo "-t, --tag          The tag name to use for the built image"
   echo ""
   echo "Usage:"
-  echo "${0} [-f|--file path/to/Dockerfile] --image example-docker-manifest --tag 1.0.0-8-jdk-openj9-bionic [-c|--context .] [--build-args \"FOO=bar\"] [--build-opts \"--pull\"] [--push] [--official] [--dry-run]"
+  echo "${0} [-f|--file path/to/Dockerfile] --image example-docker-manifest:1.0.0-8-jdk-openj9-bionic [-c|--context .] [--build-args \"FOO=bar\"] [--build-opts \"--pull\"] [--push] [--official] [--dry-run]"
   echo ""
 }
 
-if [[ "$*" == "" ]] || [[ "$*" != *--image* ]] || [[ "$*" != *--tag* ]]; then
+if [[ "$*" == "" ]] || [[ "$*" != *--image* ]]; then
   usage
   exit 1
 fi
@@ -60,11 +59,7 @@ while [[ $# -gt 0 ]]; do
     shift
     ;;
     -i|--image)
-    DOCKER_IMAGE_NAME=$2
-    shift
-    ;;
-    -t|--tag)
-    DOCKER_BUILD_TAG=$2
+    DOCKER_IMAGE=$2
     shift
     ;;
     --build-args)
@@ -116,6 +111,11 @@ if [[ "${FORCE_CI}" == "true" ]] || ([[ "${GIT_BRANCH}" == "${RELEASE_BRANCH:-ma
   if [[ -z ${DOCKER_ARCH} ]]; then
     DOCKER_ARCH=$(docker version -f {{.Server.Arch}})
   fi
+
+  # split the DOCKER_IMAGE into DOCKER_IMAGE_NAME DOCKER_TAG based on the delimiter, ':'
+  IFS=":" read -r -a image_info <<< "$DOCKER_IMAGE"
+  DOCKER_IMAGE_NAME=${image_info[0]}
+  DOCKER_BUILD_TAG=${image_info[1]}
   
   if [[ -z ${DOCKER_BUILD_TAG} ]]; then
     # if the DOCKER_BUILD_TAG is not set, default to latest

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -14,27 +14,26 @@
 
 # DOCKER_USER - Used for `docker login` to the private registry DOCKER_REGISTRY
 # DOCKER_PASS - Password for the DOCKER_USER
-# DOCKERFILE - The path to the Dockerfile used to build the image, use -f|--file if not specified in env vars
 # DOCKER_REGISTRY - Docker Registry to push the docker image and manifest to (defaults to docker.io)
 # DOCKER_NAMESPACE - Docker namespace to push the docker image to (this is your username for DockerHub)
 # DOCKER_ARCH - The CPU Architecture the docker image is being built on
 
 source ./.ci/common-functions.sh > /dev/null 2>&1 || source ./ci/common-functions.sh > /dev/null 2>&1
 
-DOCKER_BUILD_TAG=""     # The varient of the docker image to use when tagging the image (i.e. openj9-bionic)
-DOCKER_BUILD_ARGS=""    # List of build-time variables and values separated by spaces (i.e. --build-args "YCSB_VERSION=${VERSION} VAR=value")
-DOCKER_BUILD_OPTS=""    # Options passed to "docker build" command separated by spaces (i.e. --build-opts "--no-cache")
-DOCKER_BUILD_PATH="."   # The docker build context to use when building the image
-DOCKER_OFFICIAL=false   # mimic the official docker publish method for images in private registries
-DOCKER_PUSH=false       # flag to push a docker image after being built
-IS_DRY_RUN=false        # Prints out what will happen rather than running the commands
+# Default values
+DOCKER_BUILD_ARGS=""
+DOCKER_BUILD_OPTS=""
+DOCKER_BUILD_PATH="."
+DOCKER_OFFICIAL=false
+DOCKER_PUSH=false
+IS_DRY_RUN=false
 
 usage() {
-  echo -e "A docker container build script for ci pipelines \n\n"
+  echo -e "A build script for docker images to aid the publishing of multi-arch containers \n\n"
   echo "Options:"
   echo "    --build-args   Set build-time variables in a space separated string (i.e. --build-args \"FOO=bar BAR=foo\")"
-  echo "    --build-opts   Set additonal build options supported by docker (i.e. --build-opts \"--pull --no-cache\")"
-  echo "-c, --context      Docker image build path to use"
+  echo "    --build-opts   Set additonal build options supported by docker, separated by spaces (i.e. --build-opts \"--pull --no-cache\")"
+  echo "-c, --context      Docker image build path to use (Default is '.')"
   echo "    --dry-run      Print out what will happen, do not execute"
   echo "-f, --file         Name of the Dockerfile (Default is 'PATH/Dockerfile')"
   echo "-i, --image        Name of the image and optionally a tag in the 'name:tag' format"
@@ -116,7 +115,7 @@ if [[ "${FORCE_CI}" == "true" ]] || ([[ "${GIT_BRANCH}" == "${RELEASE_BRANCH:-ma
   IFS=":" read -r -a image_info <<< "$DOCKER_IMAGE"
   DOCKER_IMAGE_NAME=${image_info[0]}
   DOCKER_BUILD_TAG=${image_info[1]}
-  
+
   if [[ -z ${DOCKER_BUILD_TAG} ]]; then
     # if the DOCKER_BUILD_TAG is not set, default to latest
     DOCKER_BUILD_TAG="latest"

--- a/.ci/manifest.sh
+++ b/.ci/manifest.sh
@@ -20,14 +20,15 @@
 
 source ./.ci/common-functions.sh > /dev/null 2>&1 || source ./ci/common-functions.sh > /dev/null 2>&1
 
-IMAGE_MANIFEST=""        # The variant tag that will be used for the creation of the manifest, mapping all arch images to
-LATEST=false            # Flag set if the docker manifest should include the latest image (usually the most verbose default variant/tag)
-DOCKER_OFFICIAL=false   # mimic the official docker publish method for images in private registries
-DOCKER_PUSH=false       # flag to push a docker manifest to a registry after being created
-IS_DRY_RUN=false        # Prints out what will happen rather than running the commands
+# Default values
+IMAGE_MANIFEST=""
+LATEST=false
+DOCKER_OFFICIAL=false
+DOCKER_PUSH=false
+IS_DRY_RUN=false
 
 usage() {
-  echo -e "A docker container manifest create script for ci pipelines \n\n"
+  echo -e "A script to aid the creation of docker manifests for multi-arch containers \n\n"
   echo "Options:"
   echo "    --dry-run      Print out what will happen, do not execute"
   echo "-i, --image        The name of the image"

--- a/.ci/manifest.sh
+++ b/.ci/manifest.sh
@@ -28,8 +28,16 @@ IS_DRY_RUN=false        # Prints out what will happen rather than running the co
 
 usage() {
   echo -e "A docker container manifest create script for ci pipelines \n\n"
+  echo "Options:"
+  echo "    --dry-run      Print out what will happen, do not execute"
+  echo "-i, --image        The name of the image"
+  echo "    --latest       Additionally pull and create a maifest for the latest tag"
+  echo "-m, --manifest     The variant tag that will be used for the creation of the manifest"
+  echo "    --official     Mimic the official docker publish method for images in private registries"
+  echo "    --push         Push the manifest to the specified DOCKER_REGISTRY and DOCKER_NAMESPACE"
+  echo ""
   echo "Usage:"
-  echo "${0} --image example-docker-manifest --manifest 1.0.0-8-jdk-openj9-bionic [--latest] [--push] [--official] [--dry-run]"
+  echo "${0} -i|--image example-docker-manifest -m|--manifest 1.0.0-8-jdk-openj9-bionic [--latest] [--push] [--official] [--dry-run]"
   echo ""
 }
 
@@ -45,14 +53,14 @@ while [[ $# -gt 0 ]]; do
         DOCKER_IMAGE=$2
         shift
         ;;
-        --manifest)
+        -m|--manifest)
         IMAGE_MANIFEST=$2
         shift
         ;;
-        -l|--latest)
+        --latest)
         LATEST=true
         ;;
-        -o|--official)
+        --official)
         DOCKER_OFFICIAL=true
         ;;
         --push)

--- a/.ci/push.sh
+++ b/.ci/push.sh
@@ -26,8 +26,13 @@ IS_DRY_RUN=false        # Prints out what will happen rather than running the co
 
 usage() {
   echo -e "A docker container push script for ci pipelines when tesing an image prior to uploading \n\n"
+  echo "Options:"
+  echo "    --dry-run      Print out what will happen, do not execute"
+  echo "-i, --image        The name of the image to push in the 'name:tag' format"
+  echo "    --official     Mimic the official docker publish method for images in private registries"
+  echo ""
   echo "Usage:"
-  echo "${0} --image example-docker-manifest:1.0.0-8-jdk-openj9-bionic [--official] [--dry-run]"
+  echo "${0} -i|--image example-docker-manifest:1.0.0-8-jdk-openj9-bionic [--official] [--dry-run]"
   echo ""
 }
 
@@ -43,7 +48,7 @@ while [[ $# -gt 0 ]]; do
     DOCKER_IMAGE=$2
     shift
     ;;
-    -o|--official)
+    --official)
     DOCKER_OFFICIAL=true
     ;;
     --dry-run)

--- a/.ci/push.sh
+++ b/.ci/push.sh
@@ -20,12 +20,13 @@
 
 source ./.ci/common-functions.sh > /dev/null 2>&1 || source ./ci/common-functions.sh > /dev/null 2>&1
 
-DOCKER_IMAGE=""         # The name of the image that will be pushed to the DOCKER_REGISTRY
-DOCKER_OFFICIAL=false   # mimic the official docker publish method for images in private registries
-IS_DRY_RUN=false        # Prints out what will happen rather than running the commands
+# Default values
+DOCKER_IMAGE=""
+DOCKER_OFFICIAL=false
+IS_DRY_RUN=false
 
 usage() {
-  echo -e "A docker container push script for ci pipelines when tesing an image prior to uploading \n\n"
+  echo -e "A docker push script that can be used when tesing an image prior to uploading \n\n"
   echo "Options:"
   echo "    --dry-run      Print out what will happen, do not execute"
   echo "-i, --image        The name of the image to push in the 'name:tag' format"

--- a/.ci/tag-image.sh
+++ b/.ci/tag-image.sh
@@ -34,7 +34,7 @@ usage() {
   echo "-t, --tags         List of additonal tags for the docker image to have"
   echo ""
   echo "Usage:"
-  echo "${0} --image image:tag --tags \"tag1 tag2 ... tagN\" [--official] [--dry-run]"
+  echo "${0} -i|--image image:tag -t|--tags \"tag1 tag2 ... tagN\" [--official] [--dry-run]"
   echo ""
 }
 

--- a/.ci/tag-image.sh
+++ b/.ci/tag-image.sh
@@ -27,6 +27,12 @@ IS_DRY_RUN=false        # Prints out what will happen rather than running the co
 
 usage() {
   echo -e "A docker container tagging script for ci pipelines \n\n"
+  echo "Options:"
+  echo "    --dry-run      Print out what will happen, do not execute"
+  echo "-i, --image        The name of the image in the 'name:tag' format"
+  echo "    --official     Mimic the official docker publish method for images in private registries"
+  echo "-t, --tags         List of additonal tags for the docker image to have"
+  echo ""
   echo "Usage:"
   echo "${0} --image image:tag --tags \"tag1 tag2 ... tagN\" [--official] [--dry-run]"
   echo ""
@@ -48,7 +54,7 @@ while [[ $# -gt 0 ]]; do
     TAGS=$2
     shift
     ;;
-    -o|--official)
+    --official)
     DOCKER_OFFICIAL=true
     ;;
     --dry-run)

--- a/.ci/tag-image.sh
+++ b/.ci/tag-image.sh
@@ -20,13 +20,14 @@
 
 source ./.ci/common-functions.sh > /dev/null 2>&1 || source ./ci/common-functions.sh > /dev/null 2>&1
 
-IMAGE=""                # The docker image (including root tag) to use when making a new tag (image:tag)
-TAGS=""                 # A list of new tags that the image will become i.e. "tag1 tag2 ... tagN"
-DOCKER_OFFICIAL=false   # mimic the official docker publish method for images in private registries
-IS_DRY_RUN=false        # Prints out what will happen rather than running the commands
+# Default values
+IMAGE=""
+TAGS=""
+DOCKER_OFFICIAL=false
+IS_DRY_RUN=false
 
 usage() {
-  echo -e "A docker container tagging script for ci pipelines \n\n"
+  echo -e "A docker image tagging script for releasing alternate tag names to an image \n\n"
   echo "Options:"
   echo "    --dry-run      Print out what will happen, do not execute"
   echo "-i, --image        The name of the image in the 'name:tag' format"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,23 +21,24 @@ jobs:
     os: linux
     arch: amd64
     script:
-      - './.ci/build.sh -f 8/jdk/Dockerfile.openj9 --image ${DOCKER_IMAGE} --tag ${VERSION}-8-jdk-openj9-bionic --push'
-      - './.ci/build.sh -f 8/jdk/Dockerfile.hotspot --image ${DOCKER_IMAGE} --tag ${VERSION}-8-jdk-hotspot-bionic --push'
+      - './.ci/build.sh -f 8/jdk/Dockerfile.openj9 --image ${DOCKER_IMAGE}:${VERSION}-8-jdk-openj9-bionic --push'
+      - './.ci/build.sh -f 8/jdk/Dockerfile.hotspot --image ${DOCKER_IMAGE}:${VERSION}-8-jdk-hotspot-bionic --push'
   - os: linux
     arch: s390x
     script:
-      - './.ci/build.sh -f 8/jdk/Dockerfile.openj9 --image ${DOCKER_IMAGE} --tag ${VERSION}-8-jdk-openj9-bionic --push'
-      - './.ci/build.sh -f 8/jdk/Dockerfile.hotspot --image ${DOCKER_IMAGE} --tag ${VERSION}-8-jdk-hotspot-bionic --push'
+      - './.ci/build.sh -f 8/jdk/Dockerfile.openj9 --image ${DOCKER_IMAGE}:${VERSION}-8-jdk-openj9-bionic --push'
+      - './.ci/build.sh -f 8/jdk/Dockerfile.hotspot --image ${DOCKER_IMAGE}:${VERSION}-8-jdk-hotspot-bionic --push'
   - if: branch = master AND type != pull_request
     os: linux
     arch: ppc64le
     script:
-      - './.ci/build.sh -f 8/jdk/Dockerfile.openj9 --image ${DOCKER_IMAGE} --tag ${VERSION}-8-jdk-openj9-bionic --push'
-      - './.ci/build.sh -f 8/jdk/Dockerfile.hotspot --image ${DOCKER_IMAGE} --tag ${VERSION}-8-jdk-hotspot-bionic --push'
+      - './.ci/build.sh -f 8/jdk/Dockerfile.openj9 --image ${DOCKER_IMAGE}:${VERSION}-8-jdk-openj9-bionic --push'
+      - './.ci/build.sh -f 8/jdk/Dockerfile.hotspot --image ${DOCKER_IMAGE}:${VERSION}-8-jdk-hotspot-bionic --push'
 
   - stage: Tag
     if: branch = master AND type != pull_request
     os: linux
+    arch: s390x
     script:
       - './.ci/tag-image.sh --image ${DOCKER_IMAGE}:${VERSION}-8-jdk-openj9-bionic --tags "${VERSION}-8-openj9-bionic ${VERSION}-openj9 ${VERSION} latest"'
       - './.ci/tag-image.sh --image ${DOCKER_IMAGE}:${VERSION}-8-jdk-hotspot-bionic --tags "${VERSION}-8-hotspot-bionic ${VERSION}-8-hotspot ${VERSION}-hotspot"'
@@ -45,6 +46,7 @@ jobs:
   - stage: Manifest
     if: branch = master AND type != pull_request
     os: linux
+    arch: s390x
     script:
       - sudo bash ./.ci/enable-experimental.sh
       - sudo bash ./.ci/manifest.sh --image ${DOCKER_IMAGE} --manifest ${VERSION}-8-jdk-openj9-bionic --latest --push

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     - DOCKER_NAMESPACE=jacart
     - DOCKER_IMAGE=example-docker-manifest
     - SUPPORTED_ARCHITECTURES="amd64 s390x ppc64le"
-    - VERSION=$(cat VERSION)
+    - VERSION=$(cat VERSION)  # $(cat VERSION) or TRAVIS_BUILD_ID or $(git log -1 --pretty=%h)
 
 jobs:
   include:


### PR DESCRIPTION
- Added better usage info to build scripts - view by running the script without options/arguments
```
~ ./.ci/build.sh                                                                            
A build script for docker images to aid the publishing of multi-arch containers 


Options:
    --build-args   Set build-time variables in a space separated string (i.e. --build-args "FOO=bar BAR=foo")
    --build-opts   Set additonal build options supported by docker, separated by spaces (i.e. --build-opts "--pull --no-cache")
-c, --context      Docker image build path to use (Default is '.')
    --dry-run      Print out what will happen, do not execute
-f, --file         Name of the Dockerfile (Default is 'PATH/Dockerfile')
-i, --image        Name of the image and optionally a tag in the 'name:tag' format
    --official     Mimic the official docker publish method for images in private registries
    --push         Push the image to the specified DOCKER_REGISTRY and DOCKER_NAMESPACE

Usage:
./.ci/build.sh [-f|--file path/to/Dockerfile] --image example-docker-manifest:1.0.0-8-jdk-openj9-bionic [-c|--context .] [--build-args "FOO=bar"] [--build-opts "--pull"] [--push] [--official] [--dry-run]



~ ./.ci/push.sh                                                                    
A docker push script that can be used when tesing an image prior to uploading 


Options:
    --dry-run      Print out what will happen, do not execute
-i, --image        The name of the image to push in the 'name:tag' format
    --official     Mimic the official docker publish method for images in private registries

Usage:
./.ci/push.sh -i|--image example-docker-manifest:1.0.0-8-jdk-openj9-bionic [--official] [--dry-run]



~ ./.ci/tag-image.sh                                                           
A docker image tagging script for releasing alternate tag names to an image 


Options:
    --dry-run      Print out what will happen, do not execute
-i, --image        The name of the image in the 'name:tag' format
    --official     Mimic the official docker publish method for images in private registries
-t, --tags         List of additonal tags for the docker image to have

Usage:
./.ci/tag-image.sh -i|--image image:tag -t|--tags "tag1 tag2 ... tagN" [--official] [--dry-run]



~ ./.ci/manifest.sh                                                            
A script to aid the creation of docker manifests for multi-arch containers 


Options:
    --dry-run      Print out what will happen, do not execute
-i, --image        The name of the image
    --latest       Additionally pull and create a maifest for the latest tag
-m, --manifest     The variant tag that will be used for the creation of the manifest
    --official     Mimic the official docker publish method for images in private registries
    --push         Push the manifest to the specified DOCKER_REGISTRY and DOCKER_NAMESPACE

Usage:
./.ci/manifest.sh -i|--image example-docker-manifest -m|--manifest 1.0.0-8-jdk-openj9-bionic [--latest] [--push] [--official] [--dry-run]
``` 
- Updated `build.sh` to no longer have the `--tag` option, functionality consolidated into the `--image` option
  - `.ci/build.sh --image example --tag tag1` -> `.ci/build.sh --image example:tag1`