### PR TITLE
Update get arch function

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -112,7 +112,12 @@ if [[ "${FORCE_CI}" == "true" ]] || ([[ "${GIT_BRANCH}" == "${RELEASE_BRANCH:-ma
 
   # Get the Docker Architecture if not provided
   if [[ -z ${DOCKER_ARCH} ]]; then
-    DOCKER_ARCH=$(docker version -f {{.Server.Arch}})
+    DOCKER_ARCH=$(get_docker_arch)
+    log_debug "Arch: ${DOCKER_ARCH}"
+    if [[ "${DOCKER_ARCH}" == *"Unsupported architecture"* ]]; then
+      log_err "${DOCKER_ARCH}, exiting"
+      exit 1
+    fi
   fi
 
   # split the DOCKER_IMAGE into DOCKER_IMAGE_NAME DOCKER_TAG based on the delimiter, ':'

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -35,6 +35,7 @@ usage() {
   echo "    --build-args   Set build-time variables in a space separated string (i.e. --build-args \"FOO=bar BAR=foo\")"
   echo "    --build-opts   Set additonal build options supported by docker, separated by spaces (i.e. --build-opts \"--pull --no-cache\")"
   echo "-c, --context      Docker image build path to use (Default is '.')"
+  echo "    --debug        Print out additional debuging information when running"
   echo "    --dry-run      Print out what will happen, do not execute"
   echo "-f, --file         Name of the Dockerfile (Default is 'PATH/Dockerfile')"
   echo "-i, --image        Name of the image and optionally a tag in the 'name:tag' format"

--- a/.ci/common-functions.sh
+++ b/.ci/common-functions.sh
@@ -70,6 +70,29 @@ strip-uri() {
     echo ${uri}
 }
 
+get_docker_arch() {
+    # if docker is running get it from docker
+    if docker ps > /dev/null 2>&1; then
+        arch=$(docker version -f {{.Server.Arch}})
+        # armv7l just returns 'arm'
+        if [[ ${arch} == 'arm' ]]; then
+            arch='armv7l'
+        fi
+    else
+        # otherwise use this matrix to determine architecture
+        arch=""
+        case "$(uname -m)" in
+            amd64|x86_64)    arch='amd64';;
+            aarch64|arm64)   arch='arm64';;
+            armhf|armv7l)    arch='armv7l';;
+            s390x)           arch='s390x';;
+            ppc64el|ppc64le) arch='ppc64le';;
+            *) echo "Unsupported architecture $(uname -m)"; exit 1;;
+        esac
+    fi
+    echo ${arch}
+}
+
 log_debug() {
   if [[ ${IS_DEBUG} == true ]]; then
     echo "DEBU: $*"

--- a/.ci/push.sh
+++ b/.ci/push.sh
@@ -78,7 +78,11 @@ if [[ "${FORCE_CI}" == "true" ]] || ([[ "${GIT_BRANCH}" == "${RELEASE_BRANCH:-ma
 
   # Get the Docker Architecture if not provided
   if [[ -z ${DOCKER_ARCH} ]]; then
-    DOCKER_ARCH=$(docker version -f {{.Server.Arch}})
+    DOCKER_ARCH=$(get_docker_arch)
+    if [[ "${DOCKER_ARCH}" == *"Unsupported architecture"* ]]; then
+      log_err "${DOCKER_ARCH}, exiting"
+      exit 1
+    fi
   fi
 
   # split the DOCKER_IMAGE into DOCKER_IMAGE_NAME DOCKER_TAG based on the delimiter, ':'


### PR DESCRIPTION
This PR adds the ability to run the scripts without docker running on the machine with the new function getting the docker architecture which is utilizing `uname -m`

This is to allow better flexibility when running with the `--dry-run` flag